### PR TITLE
Fixed burpsuite name in installer script

### DIFF
--- a/tools-maasec.sh
+++ b/tools-maasec.sh
@@ -21,7 +21,7 @@ sudo apt install john hashcat openssl python3-cryptography
 sudo snap install zaproxy -y
 
 #sqlmap is used for sql ingjections and dirb to find directories on a web server
-sudo apt install burpsuite sqlmap dirb -y
+sudo apt install burp sqlmap dirb -y
 
 #python for scripting and a few other misc. tools 
 sudo apt install python3 pwncat tmux git wget curl jq htop -y


### PR DESCRIPTION
Burpsuite could not be installed using apt using the "burpsuite" alias, I changed it to "burp" to be able to find it through the package manager.