### PR TITLE
Created a Package Manager modifier script to allow people to use more than just apt.

### DIFF
--- a/mod-package-manager.py
+++ b/mod-package-manager.py
@@ -1,3 +1,8 @@
+# WARNING! This script works but the package manager of your choice might not containt the packages that we install. 
+# You WILL get many "Package not found" errors, so be prepared to use external resources. This is not a self sufficient script.
+
+
+
 #replace every instacnce in the installer file where apt is found.
 def replace_package_manager_in_file(input_file_path, output_file_path, old_pm, new_pm):
     try:

--- a/mod-package-manager.py
+++ b/mod-package-manager.py
@@ -1,0 +1,31 @@
+#replace every instacnce in the installer file where apt is found.
+def replace_package_manager_in_file(input_file_path, output_file_path, old_pm, new_pm):
+    try:
+        with open(input_file_path, 'r') as input_file:
+            content = input_file.read()
+
+        updated_content = content.replace(old_pm, new_pm)
+        with open(output_file_path, 'w') as output_file:
+            output_file.write(updated_content)
+
+        print("Operation succesfull!")
+    # This should be incredibly rare, because it is fully specified, still handling it
+    except FileNotFoundError:
+        print("File not found, please try again")
+    except Exception as e:
+        print("Error" + str(e))
+
+
+def main():
+    #Initialize variables wtih base tools file, Output name is unimportant, so you can change it
+    input_file_path = "tools-maasec.sh"
+    output_file_path = "custom-pm-tools-maasec.sh"
+    #Use a space before and after apt to not cause errors if "apt" is a substring of a package
+    old_pm = " apt "
+    # Add a space before and after the input given to not cause formatting errors
+    new_pm = " " + input("What packacge manager do you want to use?") + " "
+    replace_package_manager_in_file(input_file_path, output_file_path, old_pm, new_pm)
+    
+
+if __name__ == "__main__":
+    main()

--- a/tools-maasec.sh
+++ b/tools-maasec.sh
@@ -60,12 +60,15 @@ wget "$AC_URL" -O "$AC_FILENAME"
 #Unzip 
 tar -zxvf "$AC_FILENAME"
 cd "$AC_DIRNAME" || exit
+# Configuration and installation using aircrack's makefiles
 autoreconf -i
 ./configure --with-experimental
 make
 make install
+#Update dynamic linker cache
 ldconfig
 cd ..
+#Remove waste
 rm -f "$AC_FILENAME"
 rm -rf "$AC_DIRNAME"
 

--- a/tools-maasec.sh
+++ b/tools-maasec.sh
@@ -55,7 +55,9 @@ AC_URL="https://download.aircrack-ng.org/aircrack-ng-1.7.tar.gz"
 AC_FILENAME="aircrack-ng-1.7.tar.gz"
 AC_DIRNAME="aircrack-ng-1.7"
 
+#Download the aircrack file
 wget "$AC_URL" -O "$AC_FILENAME"
+#Unzip 
 tar -zxvf "$AC_FILENAME"
 cd "$AC_DIRNAME" || exit
 autoreconf -i
@@ -63,5 +65,8 @@ autoreconf -i
 make
 make install
 ldconfig
+cd ..
+rm -f "$AC_FILENAME"
+rm -rf "$AC_DIRNAME"
 
 echo "Aircrack-ng installation completed successfully!"

--- a/tools-maasec.sh
+++ b/tools-maasec.sh
@@ -45,3 +45,23 @@ chmod +x burpsuite.sh
 yes "" | sudo ./burpsuite.sh
 rm ./burpsuite.sh
 echo "Done!"
+
+
+# Certain packages that might be needed for the aircrack-ng installation, needs testing.
+sudo apt-get autoconf -y
+sudo apt install automake libtool shtool pkg-config ethtool rfkill build-essential -y
+
+AC_URL="https://download.aircrack-ng.org/aircrack-ng-1.7.tar.gz"
+AC_FILENAME="aircrack-ng-1.7.tar.gz"
+AC_DIRNAME="aircrack-ng-1.7"
+
+wget "$AC_URL" -O "$AC_FILENAME"
+tar -zxvf "$AC_FILENAME"
+cd "$AC_DIRNAME" || exit
+autoreconf -i
+./configure --with-experimental
+make
+make install
+ldconfig
+
+echo "Aircrack-ng installation completed successfully!"


### PR DESCRIPTION
Wrote a python script that allows the user to specify which package manager they want to use. The script searches the tools installer file and then replaces all instances of "apt" with the specified package manager. 

This assumes that the person installing has the package manager set-up on their system and also that the packages specified inside the installer script exist inside the database of the package manager. 

There exists a warning at the top that informs the user about these issues.


I tested it and the replacement works as expected.